### PR TITLE
Stack - Fix Bug

### DIFF
--- a/src/main/java/structure/stack/YeyStack.java
+++ b/src/main/java/structure/stack/YeyStack.java
@@ -28,11 +28,12 @@ public class YeyStack {
 
   public int size() {
     int counter = 1;
+    YeyStackNode temp = this.top;
 
     if (isEmpty()) return 0;
 
-    while (top.next != null) {
-      top = top.next;
+    while (temp.next != null) {
+      temp = temp.next;
       counter++;
     }
 

--- a/src/test/java/structure/stack/YeyStackTest.java
+++ b/src/test/java/structure/stack/YeyStackTest.java
@@ -40,5 +40,9 @@ public class YeyStackTest {
     classUnderTest.push("Halo");
 
     assertEquals(2, classUnderTest.size());
+
+    assertEquals("Halo", classUnderTest.pop());
+    assertEquals("Semua", classUnderTest.pop());
+    assertEquals(0, classUnderTest.size());
   }
 }


### PR DESCRIPTION
## Description

### Bug
If i call the size two times, for some reason the content of the pop is no longer right. It is caused by the pointer is jumbled together because there is no temporary variable to hold values for iterative process of counting elements.

### Fixes
Forgot to put temporary variables for iterative processes. Make the function not reusable. So I just add `temp` variables.